### PR TITLE
fix: stabilize CI by trimming fragile check dependencies

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::testthat, any::knitr
+          extra-packages: any::rcmdcheck, any::testthat, any::knitr, any::rmarkdown
           dependencies: '"hard"'
           needs: check
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::testthat
+          extra-packages: any::rcmdcheck, any::testthat, any::knitr
           dependencies: '"hard"'
           needs: check
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,7 +41,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: any::rcmdcheck, any::testthat
+          dependencies: '"hard"'
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ doc
 .Rproj.user
 .Rhistory
 .RData
+..RCheck
 src/*.o
 src/*.so
 src/*.dll

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,3 +1,3 @@
 ##PKG_CXXFLAGS = -I../inst/include
-PKG_LIBS = `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"` $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
+PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 CXX=clang++

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
 ## optional
 ## CXX_STD = CXX11
-PKG_LIBS=$(shell $(R_HOME)/bin/Rscript.exe -e "Rcpp:::LdFlags()") $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
+PKG_LIBS=$(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 CXX=clang++


### PR DESCRIPTION
## Summary
- install only hard dependencies in CI
- keep the vignette build working by explicitly installing `knitr` and `rmarkdown`
- remove deprecated `Rcpp:::LdFlags()` usage from the package Makevars files

## Why
Recent failures were not caused by GDINA test regressions. CI was failing because:
- optional suggested packages could fail during installation on old R versions
- R-devel warns on the deprecated `Rcpp:::LdFlags()` pattern
- the package build still needs `knitr` and `rmarkdown` because the repo includes a vignette

## Validation
- `R CMD INSTALL .`
- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check . --no-manual`
- local check reaches `Running 'testthat.R' OK`
