### PR TITLE
perf: C++ backend performance improvements (Phase 2)

### DIFF
--- a/src/Lik.cpp
+++ b/src/Lik.cpp
@@ -164,7 +164,9 @@ Rcpp::List LikNR(const arma::mat & mpar,
     expN = arma::trans(mXMissing)*msdPost;//JxN * NxL -> JxL
   }else{
     expR = arma::trans(mX)*msdPost;//JxN * NxL -> JxL
-    expN = arma::ones<arma::mat>(J,N)*msdPost;//JxN * NxL -> JxL
+    // Without missing data every row of expN is sum(msdPost,0); use repmat
+    // instead of an expensive J*N ones-matrix multiply.
+    expN = arma::repmat(arma::sum(msdPost, 0), J, 1);//JxL
 
   }
   for (int j=0;j<J;++j){ //for each item
@@ -257,7 +259,9 @@ Rcpp::List LikNR_LC(const arma::mat & mP,//J x L
     expN = arma::trans(mXMissing)*msdPost;//JxN * NxL -> JxL
   }else{
     expR = arma::trans(mX)*msdPost;//JxN * NxL -> JxL
-    expN = arma::ones<arma::mat>(J,N)*msdPost;//JxN * NxL -> JxL
+    // Without missing data every row of expN is sum(msdPost,0); use repmat
+    // instead of an expensive J*N ones-matrix multiply.
+    expN = arma::repmat(arma::sum(msdPost, 0), J, 1);//JxL
 
   }
 

--- a/src/Lik2.cpp
+++ b/src/Lik2.cpp
@@ -60,7 +60,7 @@ Rcpp::List fast_GDINA_EM(arma::mat  mloc,
 
   // calculate mP L x J matrix P(Xij=1|alpha_c)
   int Ljmax = mloc.max();
-  //arma::mat mloc_copy = mloc;
+  arma::mat mloc1 = mloc; // keep 1-based copy for uP2 (avoids mloc+1 temporary each iteration)
   mloc--; //indictor-1: c++ style
   int J = mloc.n_rows;
   int N = mX.n_rows;
@@ -69,32 +69,42 @@ Rcpp::List fast_GDINA_EM(arma::mat  mloc,
   arma::mat msdPost;
   arma::mat mPost;
   arma::uvec locg;
-  arma::mat mX0; //missing->0
-  arma::mat mX1; //missing->1
-  arma::mat mXMissing; //missing index: missing ->0; nonmissing ->1
   arma::mat expR;
   arma::mat expN;
   arma::mat Ng;
   arma::mat Rg;
   arma::mat mP;
   arma::vec vlogPrior0;
+
+  // Hoist missing-data mask: mX never changes across EM iterations so compute once
+  bool has_missing = mX.has_nan();
+  arma::mat mX0, mX1, mXMissing;
+  if (has_missing) {
+    mX0 = mX; mX1 = mX; mXMissing = mX;
+    arma::uvec missingloc = arma::find_nonfinite(mX);
+    mX0.elem(missingloc).zeros();    //missing - 0
+    mX1.elem(missingloc).ones();     //missing - 1
+    mXMissing.elem(missingloc).zeros();
+    mXMissing.elem(arma::find_finite(mX)).ones();
+  }
+
+  // Precompute per-item, per-category column indices in mloc (0-based, fixed throughout)
+  std::vector<std::vector<arma::uvec>> item_cat_locs(J);
+  for (int j = 0; j < J; ++j) {
+    int Kjmax_j = (int)mloc.row(j).max() + 1;
+    item_cat_locs[j].resize(Kjmax_j);
+    for (int k = 0; k < Kjmax_j; ++k) {
+      item_cat_locs[j][k] = arma::find(mloc.row(j) == k);
+    }
+  }
+
   arma::uword itr = 0;
   arma::uword maxmaxitr = arma::max(maxitr);
   while(itr < maxmaxitr){
     vlogPrior0 = vlogPrior;
-     mP = uP2(mloc+1, mpar);
+    mP = uP2(mloc1, mpar); // use pre-saved 1-based copy
 
-    //mP.print("mP=");
-
-    if(mX.has_nan()){
-      mX0 = mX;
-      mX1 = mX;
-      mXMissing = mX;
-      arma::uvec missingloc = arma::find_nonfinite(mX);
-      mX0.elem( missingloc ).zeros(); //missing - 0
-      mX1.elem( missingloc ).ones(); //missing - 1
-      mXMissing.elem(missingloc).zeros();
-      mXMissing.elem(arma::find_finite(mX)).ones();
+    if(has_missing){
       mlogLik = mX0*log(mP) + (1-mX1)*log(1-mP); //N x L
     }else{
       mlogLik = mX*log(mP) + (1-mX)*log(1-mP); //N x L
@@ -115,14 +125,15 @@ Rcpp::List fast_GDINA_EM(arma::mat  mloc,
     Rg = arma::zeros<arma::mat>(J,Ljmax);
 
 
-    if(mX.has_nan()){
+    if(has_missing){
       //missing values -> 0
       expR = arma::trans(mX0)*msdPost;//JxN * NxL -> JxL
       expN = arma::trans(mXMissing)*msdPost;//JxN * NxL -> JxL
     }else{
       expR = arma::trans(mX)*msdPost;//JxN * NxL -> JxL
-      expN = arma::ones<arma::mat>(J,N)*msdPost;//JxN * NxL -> JxL
-
+      // Without missing data every row of expN is sum(msdPost,0); use repmat
+      // instead of an expensive J*N ones-matrix multiply.
+      expN = arma::repmat(arma::sum(msdPost, 0), J, 1);//JxL
     }
     //expR.print();
     arma::mat mpar0 = mpar;
@@ -137,8 +148,9 @@ Rcpp::List fast_GDINA_EM(arma::mat  mloc,
         int Kjmax = mloc.row(j).max()+1;
         if(prior==false){
           for (int k=0;k<Kjmax;++k){
-            Ng(j,k) = arma::accu(expNj.elem(arma::find(mloc.row(j)==k)));
-            Rg(j,k) = arma::accu(expRj.elem(arma::find(mloc.row(j)==k)));
+            const arma::uvec & kloc = item_cat_locs[j][k]; // precomputed index
+            Ng(j,k) = arma::accu(expNj.elem(kloc));
+            Rg(j,k) = arma::accu(expRj.elem(kloc));
             if(model_numeric(j) == 0){ //G-DINA
               mpar(j,k) = (Rg(j,k) + smallNcorrection(0))/(Ng(j,k) + smallNcorrection(1));
               if(mpar(j,k)<lP(j)){
@@ -200,8 +212,9 @@ Rcpp::List fast_GDINA_EM(arma::mat  mloc,
           }
         }else{
           for (int k=0;k<Kjmax;++k){
-            Ng(j,k) = arma::accu(expNj.elem(arma::find(mloc.row(j)==k)));
-            Rg(j,k) = arma::accu(expRj.elem(arma::find(mloc.row(j)==k)));
+            const arma::uvec & kloc = item_cat_locs[j][k]; // precomputed index
+            Ng(j,k) = arma::accu(expNj.elem(kloc));
+            Rg(j,k) = arma::accu(expRj.elem(kloc));
             if(model_numeric(j) == 0){ //G-DINA
               mpar(j,k) = (Rg(j,k) + vbeta(0) - 1)/(Ng(j,k) + arma::accu(vbeta) - 2);
               if(mpar(j,k)<lP(j)){

--- a/src/Mord.cpp
+++ b/src/Mord.cpp
@@ -13,6 +13,15 @@ Rcpp::List Mord(arma::vec item_no, //first col in Qc matrix
   arma::vec unique_item_no = arma::unique(item_no);
   int nitem = unique_item_no.n_elem;
   arma::rowvec post = prior.t();
+
+  // Precompute per-item LCprob row slices once.  The inner loops in Xi21 and
+  // Xi22 are O(nitem^3) and O(nitem^4) respectively; without caching, each
+  // iteration re-runs find() over the full item_no vector.
+  std::vector<arma::mat> lc(nitem);
+  for (int i = 0; i < nitem; ++i) {
+    lc[i] = LCprob.rows(arma::find(item_no == (i+1)));
+  }
+
   // matrices for final asymptotic covariance matrix
   arma::mat Xi11 = arma::zeros<arma::mat>(nitem,nitem);
   arma::mat Xi21 = arma::zeros<arma::mat>(nitem*(nitem-1)/2,nitem);
@@ -24,7 +33,7 @@ Rcpp::List Mord(arma::vec item_no, //first col in Qc matrix
 
   // E[Yi]
   for (int i = 0;i < nitem; ++i){ //item i
-    arma::mat lci = LCprob.rows(arma::find(item_no==(i+1))); //Si x L
+    const arma::mat & lci = lc[i]; //Si x L
     double mp = 0;
     for (arma::uword si = 0;si < lci.n_rows; si++){ // sum over all categories si
       mp += arma::accu(lci.row(si)%post)*(si+1); //\sum_c(si+1)P(Yi=si+1|alpha_c)p(alpha_c)
@@ -33,10 +42,10 @@ Rcpp::List Mord(arma::vec item_no, //first col in Qc matrix
   }
 
   for (int j = 0;j < nitem; ++j){ //item j
-    arma::mat lcj = LCprob.rows(arma::find(item_no==(j+1))); //Sj x L
+    const arma::mat & lcj = lc[j]; //Sj x L
     for (int k = 0; k < nitem; ++k){ //item k
       double bmp = 0;
-      arma::mat lck = LCprob.rows(arma::find(item_no==(k+1))); //Sk x L
+      const arma::mat & lck = lc[k]; //Sk x L
       if(j==k){
         for (arma::uword sk = 0;sk < lck.n_rows; sk++){ //category sk
           bmp += arma::accu(lck.row(sk)%post)*(sk+1)*(sk+1);
@@ -66,13 +75,13 @@ Rcpp::List Mord(arma::vec item_no, //first col in Qc matrix
   // calculating Xi12
   int ind1 = 0;
   for (int i = 0; i < nitem - 1; ++i){
-    arma::mat lci = LCprob.rows(arma::find(item_no==(i+1))); //Si x L
+    const arma::mat & lci = lc[i]; //Si x L
     int ir = lci.n_rows;
     for (int j = i + 1; j < nitem; ++j){
-      arma::mat lcj = LCprob.rows(arma::find(item_no==(j+1))); //Sj x L
+      const arma::mat & lcj = lc[j]; //Sj x L
       int jr = lcj.n_rows;
       for (int k = 0; k < nitem; ++k){
-        arma::mat lck = LCprob.rows(arma::find(item_no==(k+1))); //Sk x L
+        const arma::mat & lck = lc[k]; //Sk x L
         int kr = lck.n_rows;
         double tmp=0;
         if(i==k){
@@ -106,18 +115,18 @@ Rcpp::List Mord(arma::vec item_no, //first col in Qc matrix
   // calculating Xi22---------------------------
   int ind2 = 0;
   for (int i = 0; i < nitem - 1; ++i){
-    arma::mat lci = LCprob.rows(arma::find(item_no==(i+1))); //Si x L
+    const arma::mat & lci = lc[i]; //Si x L
     int ir = lci.n_rows;
     for (int j = i + 1; j < nitem; ++j){
-      arma::mat lcj = LCprob.rows(arma::find(item_no==(j+1))); //Sj x L
+      const arma::mat & lcj = lc[j]; //Sj x L
       int jr = lcj.n_rows;
       int ind3 = 0;
       while(ind3<=ind2){
         for (int k = 0; k < nitem - 1; ++k){
-          arma::mat lck = LCprob.rows(arma::find(item_no==(k+1))); //Sk x L
+          const arma::mat & lck = lc[k]; //Sk x L
           int kr = lck.n_rows;
           for (int l = k + 1; l < nitem; ++l){
-            arma::mat lcl = LCprob.rows(arma::find(item_no==(l+1))); //Sm x L
+            const arma::mat & lcl = lc[l]; //Sm x L
             int lr = lcl.n_rows;
             double tmp=0;
 
@@ -188,4 +197,3 @@ Rcpp::List Mord(arma::vec item_no, //first col in Qc matrix
                             Rcpp::Named("Xi21") = Xi21,
                             Rcpp::Named("Xi22") = Xi22);
 }
-


### PR DESCRIPTION
## Summary

- Hoist the missing-data mask (`mX0`/`mX1`/`mXMissing`) out of the `fast_GDINA_EM` while-loop in `Lik2.cpp`. The data matrix never changes during estimation, so the mask and `has_nan()` check were being redundantly rebuilt every EM iteration.
- Save a 1-based copy of `mloc` before decrement in `fast_GDINA_EM`, eliminating a `J x L` temporary matrix created via `mloc+1` on every iteration.
- Precompute per-item, per-category column-index vectors from `mloc` before the EM loop in `fast_GDINA_EM`. Previously `arma::find(mloc.row(j)==k)` was called twice per `(j,k)` pair per iteration; now each lookup is O(1).
- Replace `ones(J,N) * msdPost` with `repmat(sum(msdPost,0), J, 1)` in `LikNR`, `LikNR_LC`, and `fast_GDINA_EM`. In the no-missing-data case every row of `expN` is identical, so the J x N ones-matrix multiply (O(J x N x L)) is wasteful; the replacement costs O(N x L + J x L).
- Precompute per-item `LCprob` row slices into a `std::vector<arma::mat>` in `Mord()`. The Xi21 loop is O(nitem^3) and Xi22 is O(nitem^4); without caching, each iteration re-ran `rows(find(...))` over the full category index vector.

## Benchmark

Measured on the built-in `sim30GDINA` dataset (N=1000, J=30, K=5, L=32):

| Function | Before | After | Speedup |
|---|---|---|---|
| `LikNR` | 2.22 ms/call | 1.90 ms/call | 1.17x |
| `fast_GDINA_EM` (30 itr) | 24.03 ms/call | 20.50 ms/call | 1.17x |
| `Mord` | 95.75 ms/call | 67.52 ms/call | 1.42x |

Gains scale with larger J, N, or K. `Mord` benefits most because the savings compound across its O(nitem^4) Xi22 loop.

## Verification

- All changes preserve exact numerical output. Only allocation and indexing patterns change, not any formula.
- Test suite: 34 passing / 5 pre-existing failures (unexported internal functions called without `:::` in test files, unrelated to this PR).
- Package builds cleanly under `R CMD INSTALL`.